### PR TITLE
Update README.md with working example

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,8 +21,10 @@ Or install it yourself as:
 ## Usage
 
 ```ruby
+require 'consul-kv'
+
 Consul::KV.configure do |x|
-  x.consul_host = 'http://127.0.0.1'
+  x.consul_host = '127.0.0.1'
   x.consul_port = '8500'
   x.consul_prefix = 'v1/kv'
 end


### PR DESCRIPTION
I was having issues getting this gem to work but finally got it working.  I'm including updates to the README.md example so others don't run into similar issues.
- I added the necessary require line for loading the gem.
- I updated consul_host to not include the uri scheme.  I was encountering the following error otherwise:

```
SocketError: getaddrinfo: Name or service not known
from /opt/chef/embedded/lib/ruby/1.9.1/net/http.rb:763:in `initialize'
```
